### PR TITLE
Update redix_pubsub link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ reconnections.
 #### Pub/Sub
 
 Redix doesn't support the Pub/Sub features of Redis. For that, there's
-[`redix_pub_sub`][redix-pub-sub] :).
+[`redix_pubsub`][redix-pubsub] :).
 
 ## Using Redix in the Real World™
 
@@ -144,6 +144,6 @@ MIT &copy; 2015 Andrea Leopardi, see the [license file](LICENSE.txt).
 [redis]: http://redis.io
 [connection]: https://github.com/fishcakez/connection
 [poolboy]: https://github.com/devinus/poolboy
-[redix-pub-sub]: https://github.com/whatyouhide/redix_pub_sub
+[redix-pubsub]: https://github.com/whatyouhide/redix_pubsub
 [docs-reconnections]: http://hexdocs.pm/redix/reconnections.html
 [docs-real-world-usage]: http://hexdocs.pm/redix/real-world-usage.html


### PR DESCRIPTION
There are some confusing things in this latest release of Redix. One is that redix_pubsub was moved to it's own project, but the link was broken. Once I found redix_pubsub, I followed the install instructions, but it is not yet in Hex which is stated. I added Redix PubSub to mix.deps using the Git link directly, but then had a version conflict because it has a dependency on Redix. Since I need both Redix and Redix PubSub functionality, there is a bit of a circular dependency problem introduced by separating out the project.
